### PR TITLE
If we are running fasttrack tests, enable the fasttrack repo

### DIFF
--- a/tests/0_common/000_centos_default_repos.py
+++ b/tests/0_common/000_centos_default_repos.py
@@ -9,9 +9,20 @@
 import yum
 import sys 
 import datetime
+import os
 
 yb = yum.YumBase()
-centos_default_repos = ['base','extras','updates','cr','fasttrack']
+
+try:
+    fasttrack = int(os.environ['FASTTRACK'])
+except KeyError:
+    fasttrack = 0
+
+if fasttrack:
+    centos_default_repos = ['base','extras','updates','cr','fasttrack']
+else:
+    centos_default_repos = ['base','extras','updates','cr']
+
 now = lambda: datetime.datetime.today().strftime("%c")
 print "[+] %s -> Check if non default repo is enabled" % now() 
 for repo in yb.repos.listEnabled():


### PR DESCRIPTION
This expects an environment variable FASTTRACK to be specified for our fasttrack tests. If that environment var is set, add the fasttrack repo to our default repos list. 
